### PR TITLE
ACOMPTE : AJOUT ZONE TEXTE 'reste a repartir', [devis] bouton menu ac…

### DIFF
--- a/abei_acompte/views/acompte.xml
+++ b/abei_acompte/views/acompte.xml
@@ -72,8 +72,12 @@
                                 </page>
                             </notebook>
                         </div>
-                        <group class="oe_subtotal_footer h3" name="montant_total">
-                            <field name="montant_total_lignes_acompte"/>
+                        <group class="oe_subtotal_footer oe_right" colspan="2" name="acompte_total">
+                            <field name="reste_a_repartir" widget="monetary" options="{'currency_field': 'currency_id'}"/>
+                            <div class="oe_subtotal_footer_separator oe_inline o_td_label">
+                                <label for="montant_total_lignes_acompte"/>
+                            </div>
+                            <field name="montant_total_lignes_acompte" nolabel="1" class="oe_subtotal_footer_separator" widget="monetary" options="{'currency_field': 'currency_id'}"/>
                         </group>
                     </sheet>
                 </form>

--- a/abei_acompte/views/sale_views.xml
+++ b/abei_acompte/views/sale_views.xml
@@ -6,14 +6,16 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='payment_term_id']" position="after">
                 <field name="acompte_checkbox"/>
+                <field name="acompte_id" invisible="1"/>
                 <field name="acompte_type" attrs="{
                 'invisible': [('acompte_checkbox', '=', False)],
                 'required': [('acompte_checkbox', '=', True)]}"/>
-                <field name="acompte_date_debut" attrs="{'invisible': [('acompte_checkbox', '=', False)],'required': [('acompte_checkbox', '=', True)]}"/>
-<!--                <field name="acompte_id"/>-->
+                <field name="acompte_date_debut" attrs="{
+                'invisible': [('acompte_checkbox', '=', False)],
+                'required': [('acompte_checkbox', '=', True)]}"/>
             </xpath>
             <xpath expr="//div[hasclass('oe_button_box')]/button[1]" position="before">
-                <button class="oe_stat_button" name="action_open_acompte" type="object" icon="fa-book" attrs="{'invisible': [('acompte_checkbox', '=', False)]}" string="Acomptes"/>
+                <button class="oe_stat_button" name="action_open_acompte" type="object" icon="fa-book" attrs="{'invisible': [('acompte_id', '=', False)]}" string="Acompte"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
1)	Le bouton menu Acompte (dans devis) ne s’affiche désormais que lorsqu’il y a des acomptes.
2)	Ajout de la zone de texte "reste à répartir" dans l’acompte.
3)	Le Total est désormais l’addition des lignes d’acompte, plutôt que la copie du « Montant à répartir » pour éviter les problèmes de centimes d’euros manquants.
4)	Dans l’acompte, la date de prochaine facture n'est plus obligatoire lors de la création depuis le devis, mais devient obligatoire lorsqu'on est dans le menu acompte et que l'on clique sur "générer".
5)	 Lorsque le type d'acompte change dans le menu acompte, le type d'acompte change également dans le devis (de même pour la Date début acompte) . (Que doit-il se passer si le montant à répartir est modifié dans l’acompte ? Doit avoir une répercussion dans le devis ?)
6)	 Dans le devis, la modification des champs : Case à cocher géré par acompte, Type d'acompte et date de début d'acompte est désormais bloquée si des acomptes sont déjà générés.

A FAIRE :

1)	Equivalent du (5) de la partie précédente, mais dans le sens Devis -> Acompte. Si un des champs géré par acompte, Type d'acompte ou date de début d'acompte sont modifiés dans le devis, répercuter les modifications dans l'acompte.
2)	Gérer les suppressions des acomptes :
- Quand il n’y a plus de lignes d’acompte et qu’il n’y a pas eu de factures, acompte supprimable.
- Si l'utilisateur supprime l'acompte, la case à coché du devis « géré par acompte » se décoche.
- Lorsqu’un acompte est supprimé, une activité doit être générée dans l’espace dédié sur l’écran « suppression de l'acompte par [utilisateur] + [date et heure] »
3)	Lors de l’édition de lignes d’acompte (la dernière ligne en particulier) la touche clavier « Entrée » ne doit pas afficher de modale.
